### PR TITLE
处理多多级table 字符串化错误的问题

### DIFF
--- a/src/stringify.lua
+++ b/src/stringify.lua
@@ -6,8 +6,8 @@ local function val_to_str ( v )
     end
     return '"' .. string.gsub(v,'"', '\\"' ) .. '"'
   else
-    return "table" == type( v ) and table.tostring( v ) or
-      tostring( v )
+    return "table" == type( v ) and table.stringify( v ) or 
+    tostring( v )
   end
 end
 


### PR DESCRIPTION
problem:
 /usr/share/lua/5.1/stringify.lua:9: attempt to call field 'tostring' (a nil value)
/usr/share/lua/5.1/stringify.lua:9: in function 'val_to_str'
/usr/share/lua/5.1/stringify.lua:32: in function 'stringify'